### PR TITLE
Switch to workflow-manager version 0.0.3-FINAL-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 		<jsonpath.version>2.1.0</jsonpath.version>
 		<snippetsDirectory>${project.build.directory}\generated-snippets</snippetsDirectory>
 		<checkstyle-plugin.version>2.17</checkstyle-plugin.version>
-		<workflow-manager.version>0.0.3-FINAL</workflow-manager.version>
+		<workflow-manager.version>0.0.3-FINAL-1</workflow-manager.version>
 		<alien4cloud.version>1.1.0-INDIGO2-ALPHA.2</alien4cloud.version>
 		<chronos-client.version>0.0.1-BETA.1</chronos-client.version>
 	</properties>


### PR DESCRIPTION
Version of the library that destroys the ExecutorService at shutdown,
closing the entity manager in the meantime; fixes #163