### PR TITLE
Fix scopes retrieval from configuration

### DIFF
--- a/src/main/java/it/reply/orchestrator/config/properties/OidcProperties.java
+++ b/src/main/java/it/reply/orchestrator/config/properties/OidcProperties.java
@@ -95,10 +95,9 @@ public class OidcProperties implements SecurityPrerequisite, InitializingBean {
   public Optional<IamProperties> getIamConfiguration(String issuer) {
     return Optional.ofNullable(iamProperties.get(issuer));
   }
-  
+
   public Set<String> getOrchestratorScopes(String issuer) {
-	    return new HashSet<>(iamProperties.get(issuer).orchestrator.scopes);
-	    
+    return new HashSet<>(iamProperties.get(issuer).orchestrator.scopes);
   }
 
   @Override
@@ -115,10 +114,11 @@ public class OidcProperties implements SecurityPrerequisite, InitializingBean {
         Assert.hasText(orchestratorConfiguration.getClientSecret(),
             "Orchestrator OAuth2 clientSecret for issuer " + issuer + " must be provided");
         if (orchestratorConfiguration.getScopes().isEmpty()) {
-            LOG.warn("No Orchestrator OAuth2 scopes provided for issuer {}. Using default: {}", issuer, REQUIRED_SCOPES);
-            orchestratorConfiguration.setScopes(new ArrayList<String>(REQUIRED_SCOPES));
-            iamConfiguration.setOrchestrator(orchestratorConfiguration);
-            iamConfigurationEntry.setValue(iamConfiguration);
+          LOG.warn("No Orchestrator OAuth2 scopes provided for issuer {}. Using default: {}",
+                  issuer, REQUIRED_SCOPES);
+          orchestratorConfiguration.setScopes(new ArrayList<String>(REQUIRED_SCOPES));
+          iamConfiguration.setOrchestrator(orchestratorConfiguration);
+          iamConfigurationEntry.setValue(iamConfiguration);
         }
 
         Optional<OidcClientProperties> cluesConfiguration = iamConfiguration.getClues();
@@ -201,15 +201,16 @@ public class OidcProperties implements SecurityPrerequisite, InitializingBean {
   @NoArgsConstructor
   public static class ScopedOidcClientProperties extends OidcClientProperties {
 
-    //@NotNull
-    //@NonNull
-    private List<String> scopes ;
-    
-    public List<String> getScopes(){
-    	if (scopes == null) {
-    		scopes = new ArrayList<String>();;
-    	}	
-    	return scopes;
+    private List<String> scopes;
+
+    /**
+     * Return the scopes.
+     */
+    public List<String> getScopes() {
+      if (scopes == null) {
+        scopes = new ArrayList<String>();
+      }
+      return scopes;
     }
   }
 }

--- a/src/main/java/it/reply/orchestrator/config/properties/OidcProperties.java
+++ b/src/main/java/it/reply/orchestrator/config/properties/OidcProperties.java
@@ -16,13 +16,16 @@
 
 package it.reply.orchestrator.config.properties;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
@@ -51,6 +54,9 @@ import org.springframework.validation.annotation.Validated;
 @Component
 public class OidcProperties implements SecurityPrerequisite, InitializingBean {
 
+  public static final Set<String> REQUIRED_SCOPES =
+      ImmutableSet.of("openid", "profile", "offline_access", "fts:submit-transfer");
+
   protected static final String PROPERTIES_PREFIX = "oidc";
 
   public static final String SECURITY_ENABLED_PROPERTY = PROPERTIES_PREFIX + ".enabled";
@@ -64,13 +70,6 @@ public class OidcProperties implements SecurityPrerequisite, InitializingBean {
   @Valid
   @NestedConfigurationProperty
   private Map<String, IamProperties> iamProperties = new HashMap<>();
-
-  @NotNull
-  @NonNull
-  @Valid
-  @NestedConfigurationProperty
-  private List<String> scopes =
-      new ArrayList<>(Arrays.asList("openid", "profile", "offline_access", "mail"));
 
   /**
    * Throw an {@link IllegalStateException} if the security is disabled.
@@ -96,6 +95,11 @@ public class OidcProperties implements SecurityPrerequisite, InitializingBean {
   public Optional<IamProperties> getIamConfiguration(String issuer) {
     return Optional.ofNullable(iamProperties.get(issuer));
   }
+  
+  public Set<String> getOrchestratorScopes(String issuer) {
+	    return new HashSet<>(iamProperties.get(issuer).orchestrator.scopes);
+	    
+  }
 
   @Override
   public void afterPropertiesSet() throws Exception {
@@ -111,7 +115,10 @@ public class OidcProperties implements SecurityPrerequisite, InitializingBean {
         Assert.hasText(orchestratorConfiguration.getClientSecret(),
             "Orchestrator OAuth2 clientSecret for issuer " + issuer + " must be provided");
         if (orchestratorConfiguration.getScopes().isEmpty()) {
-          orchestratorConfiguration.setScopes(new ArrayList<String>(scopes));
+            LOG.warn("No Orchestrator OAuth2 scopes provided for issuer {}. Using default: {}", issuer, REQUIRED_SCOPES);
+            orchestratorConfiguration.setScopes(new ArrayList<String>(REQUIRED_SCOPES));
+            iamConfiguration.setOrchestrator(orchestratorConfiguration);
+            iamConfigurationEntry.setValue(iamConfiguration);
         }
 
         Optional<OidcClientProperties> cluesConfiguration = iamConfiguration.getClues();
@@ -194,9 +201,15 @@ public class OidcProperties implements SecurityPrerequisite, InitializingBean {
   @NoArgsConstructor
   public static class ScopedOidcClientProperties extends OidcClientProperties {
 
-    @NotNull
-    @NonNull
-    private List<String> scopes = new ArrayList<>();
-
+    //@NotNull
+    //@NonNull
+    private List<String> scopes ;
+    
+    public List<String> getScopes(){
+    	if (scopes == null) {
+    		scopes = new ArrayList<String>();;
+    	}	
+    	return scopes;
+    }
   }
 }

--- a/src/main/java/it/reply/orchestrator/service/security/OAuth2TokenCacheService.java
+++ b/src/main/java/it/reply/orchestrator/service/security/OAuth2TokenCacheService.java
@@ -187,7 +187,7 @@ public class OAuth2TokenCacheService {
 
     @Autowired
     private OidcTokenRepository oidcTokenRepository;
-    
+
     @Autowired
     private OidcProperties oidcProperties;
 
@@ -208,7 +208,9 @@ public class OAuth2TokenCacheService {
                     () -> new OrchestratorException("No refresh token found for " + id));
         AccessGrant grant =
             //template.refreshToken(refreshToken.getValue(), OidcProperties.REQUIRED_SCOPES);
-        	template.refreshToken(refreshToken.getValue(), oidcProperties.getOrchestratorScopes(id.getOidcEntityId().getIssuer()));
+            template.refreshToken(refreshToken.getValue(),
+                            oidcProperties.getOrchestratorScopes(
+                                 id.getOidcEntityId().getIssuer()));
         LOG.info("Access token for {} refreshed", id);
         String newRefreshToken = grant.getRefreshToken();
         if (newRefreshToken != null && !newRefreshToken.equals(refreshToken.getValue())) {
@@ -238,9 +240,11 @@ public class OAuth2TokenCacheService {
                 "Refresh token for {} isn't active anymore."
                     + " Getting a new one exchanging access token with jti={}",
                 id, JwtUtils.getJti(JwtUtils.parseJwt(accessToken)));
-            
-            //AccessGrant grant = template.exchangeToken(accessToken, OidcProperties.REQUIRED_SCOPES);
-            AccessGrant grant = template.exchangeToken(accessToken,  oidcProperties.getOrchestratorScopes(id.getOidcEntityId().getIssuer()));
+
+            //AccessGrant grant =
+            // template.exchangeToken(accessToken, OidcProperties.REQUIRED_SCOPES);
+            AccessGrant grant = template.exchangeToken(accessToken,
+                            oidcProperties.getOrchestratorScopes(id.getOidcEntityId().getIssuer()));
             refreshToken.get().updateFromAccessGrant(grant);
             entry.setValue(grant);
             return grant;
@@ -254,7 +258,8 @@ public class OAuth2TokenCacheService {
           LOG.info("No refresh token found for {}. Exchanging access token with jti={}",
               id, JwtUtils.getJti(JwtUtils.parseJwt(accessToken)));
           //AccessGrant grant = template.exchangeToken(accessToken, OidcProperties.REQUIRED_SCOPES);
-          AccessGrant grant = template.exchangeToken(accessToken, oidcProperties.getOrchestratorScopes(id.getOidcEntityId().getIssuer()));
+          AccessGrant grant = template.exchangeToken(accessToken,
+                   oidcProperties.getOrchestratorScopes(id.getOidcEntityId().getIssuer()));
           OidcRefreshToken token = OidcRefreshToken.createFromAccessGrant(grant, entry.getKey());
           oidcTokenRepository.save(token);
           entry.setValue(grant);


### PR DESCRIPTION
Read orchestrator scopes from "oidc" properties if present, otherwise use hard-coded default.