### PR TITLE
replaced egi.eu with infn-cloud as default organization name

### DIFF
--- a/src/main/java/it/reply/orchestrator/dto/security/IamUserInfo.java
+++ b/src/main/java/it/reply/orchestrator/dto/security/IamUserInfo.java
@@ -90,7 +90,7 @@ public class IamUserInfo extends DefaultUserInfo {
   }
 
   public String getOrganizationName() {
-    return Optional.ofNullable(organizationName).orElse("egi.eu");
+    return Optional.ofNullable(organizationName).orElse("infn-cloud");
   }
 
   @Override


### PR DESCRIPTION
This change solve the issue of listing deployments and info of a deployment using a token where organization_name is not explicitly defined.